### PR TITLE
Add an efficient multistage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# build stage
+FROM ruby:2.5.0-alpine AS pre-builder
+
+ARG build_without=""
+ENV SECRET_KEY_BASE=dumb
+
+RUN apk add --update --no-cache \
+openssl \
+tar \
+build-base \
+tzdata \
+&& mkdir -p /var/app
+
+ENV BUNDLE_PATH="/gems" BUNDLE_JOBS=4 BUNDLE_WITHOUT=${bundle_without}
+
+COPY Gemfile Gemfile.lock /var/app/
+WORKDIR /var/app
+
+RUN bundle install \
+&& rm -rf /gems/cache/*.gem \
+&& find /gems/gems/ -name "*.c" -delete \
+&& find /gems/gems/ -name "*.o" -delete
+
+# final stage
+FROM ruby:2.5.0-alpine
+
+RUN apk add --update --no-cache \
+openssl \
+tzdata
+
+COPY --from=pre-builder /gems/ /gems/
+COPY . /var/app/
+
+WORKDIR /var/app
+ARG build_without=""
+ENV BUNDLE_PATH="/gems" BUNDLE_JOBS=4 BUNDLE_WITHOUT=${bundle_without}
+
+ENTRYPOINT [ "./docker/entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle exec rspec spec
+bundle exec rubocop
+bundle exec reek


### PR DESCRIPTION
This Dockerfile was added to test bulding and runner docker containers
via Github actions. It splits things up into multiple stages so that the
final image is much smaller as it does not need all the tools which were
needed to build the gems that I have included in the Gemfile.

I have now reaslied this will be generally useful outside of the Github
actions PR so I'm merging it.